### PR TITLE
(feat): Bot class and import structure refactors

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -3,29 +3,38 @@ const { setCommands } = require("./utils/setCommands");
 const { setEvents } = require("./utils/setEvents");
 
 class Bot extends Client {
-    constructor(token) {
+    constructor(clientConfiguration) {
         super({
             intents: [
                 GatewayIntentBits.Guilds,
                 GatewayIntentBits.GuildMessages,
             ],
         });
-        this.TOKEN = token;
+
         this.commands = new Collection();
+
+        const { token, commands, events } = clientConfiguration;
+        this._TOKEN = token;
+        this._commands = commands;
+        this._events = events;
     }
 
     run() {
-        this.#registerCommands(this);
-        this.#registerEvents(this);
-        this.login(this.TOKEN);
+        this.#registerClientCommands();
+        this.#registerClientEvents();
+        this.#login();
     }
 
-    #registerCommands(client) {
-        setCommands(client);
+    #login() {
+        this.login(this._TOKEN);
     }
 
-    #registerEvents(client) {
-        setEvents(client);
+    #registerClientCommands() {
+        setCommands(this, this._commands);
+    }
+
+    #registerClientEvents() {
+        setEvents(this, this._events);
     }
 }
 

--- a/src/start.js
+++ b/src/start.js
@@ -1,11 +1,18 @@
 require("dotenv").config();
 
 const { Bot } = require("./bot.js");
+const commands = require("./commands");
+const events = require("./events");
 
 const { TOKEN } = process.env;
 
 const start = async () => {
-    const client = new Bot(TOKEN);
+    const clientConfiguration = {
+        token: TOKEN,
+        commands: commands,
+        events: events,
+    };
+    const client = new Bot(clientConfiguration);
     client.run();
 };
 

--- a/src/utils/setCommands.js
+++ b/src/utils/setCommands.js
@@ -1,15 +1,15 @@
 const { Client } = require("discord.js");
-const commands = require("../commands");
 
 /**
  * Retrieves all commands and attaches to client on start.
  * Add new commands in src/commands.
  *
  * @param {Client} client
+ * @param {Array} commands
  *
  * https://discordjs.guide/creating-your-bot/command-handling.html
  */
-function setCommands(client) {
+function setCommands(client, commands) {
     commands.forEach((command) => {
         client.commands.set(command.data.name, command);
         console.log(`Command: '${command.data.name}' set on client`);

--- a/src/utils/setEvents.js
+++ b/src/utils/setEvents.js
@@ -1,17 +1,17 @@
 const { Client } = require("discord.js");
-const events = require("../events");
 
 /**
  * Retrieves all events listeners on start and registers to client.
  * Add new event listener in src/events.
  *
  * @param {Client} client
+ * @param {Array} eventListeners
  *
  * https://discordjs.guide/creating-your-bot/event-handling.html#individual-event-files
  */
 
-function setEvents(client) {
-    events.forEach((event) => {
+function setEvents(client, eventListeners) {
+    eventListeners.forEach((event) => {
         if (event.once) {
             client.once(event.name, (...args) => {
                 event.execute(...args);


### PR DESCRIPTION
`Bot` Class:
- remove extraneous `client` params
- takes in `clientConfiguration` on initialization
  - includes: `token`, `commands`, and `events`
- some more verbose variable naming
- On `setEvents` / `setCommands` usage:
    ```node
    setEvents(this, this._events);
    ```
     This may seem redundant, but I don't want to encourage any expectation of a public `events` property on `Bot`. Discord encourages a public `commands` property in their documentation, so I believe that case is okay.

Import organization:
- Token, events, and commands are all imported into `start.js`.
- This should make `Bot` and `/utils` more modular. The goal is to make unit testing their behaviors easier, as you may now inject any dependencies needed.
  - The previous implementation _could_ have been unit tested, but you'd have to get weird with mocking modules, rather than having factories or mocked objects on the fly.

Resolves Issue #9 