### PR TITLE
(feat): Pull out client configuration into it's own module

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -1,4 +1,4 @@
-const { Client, Collection, GatewayIntentBits } = require("discord.js");
+const { Client, Collection } = require("discord.js");
 const { setCommands } = require("./utils/setCommands");
 const { setEvents } = require("./utils/setEvents");
 
@@ -8,14 +8,9 @@ class Bot extends Client {
     #events;
 
     constructor(clientConfiguration) {
-        const { token, commands, events } = clientConfiguration;
+        const { token, commands, events, intents } = clientConfiguration;
 
-        super({
-            intents: [
-                GatewayIntentBits.Guilds,
-                GatewayIntentBits.GuildMessages,
-            ],
-        });
+        super({ intents });
 
         this.commands = new Collection();
 

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,16 @@
+require("dotenv").config();
+
+const { GatewayIntentBits } = require("discord.js");
+const commands = require("./commands");
+const events = require("./events");
+
+const { TOKEN } = process.env;
+
+const CLIENT_CONFIGURATION = {
+    token: TOKEN,
+    commands: commands,
+    events: events,
+    intents: [GatewayIntentBits.Guilds],
+};
+
+module.exports = { CLIENT_CONFIGURATION };

--- a/src/start.js
+++ b/src/start.js
@@ -1,18 +1,8 @@
-require("dotenv").config();
-
 const { Bot } = require("./bot.js");
-const commands = require("./commands");
-const events = require("./events");
-
-const { TOKEN } = process.env;
+const { CLIENT_CONFIGURATION } = require("./config.js");
 
 const start = async () => {
-    const clientConfiguration = {
-        token: TOKEN,
-        commands: commands,
-        events: events,
-    };
-    const client = new Bot(clientConfiguration);
+    const client = new Bot(CLIENT_CONFIGURATION);
     client.run();
 };
 


### PR DESCRIPTION
Aims to hide this information from `start.js`, and encapsulate `Bot` further.

Resolves Issue #21 and Issue #22 