### PR TITLE
(feat): Refactor application logging to use `debug` wrapper for logging.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,15 +42,13 @@ Inspired create stand-alone boiler-plate after contributions I had made to a pri
         npm install
 
 1. #### Start the Bot application.
-        npm start
-
-    ##### To Register Commands:
-        npm start --register
+        npm start [--register] (--debug | --debug="<scope>")
     
-    > Registers currently implemented commands globally
+    Options: 
 
-    > This must be done at least once and whenever you want to update registered commands with Discord's API. For more options, see [Registering Commands](#registering-commands).
+    - `--register`: Registers currently implemented slash commands with Discords API globally. See [Registering Commands](#registering-commands).
 
+    - `--debug`: Adds logging to `stdout`. See [Debug Logs](#debug-logs)
 ## Development
 
 ### Setup:
@@ -62,10 +60,13 @@ Inspired create stand-alone boiler-plate after contributions I had made to a pri
         npm run prepare
 
 1. #### Run the app in development mode.
-        npm run dev
+        npm run dev (--debug | --debug="<scope>")
+
+    Options:
+    - `--debug` Adds logging to `stdout`. For more options see [Debug Logs](#debug-logs)
+
 
 ### Adding Commands:
-> https://discordjs.guide/creating-your-bot/command-handling.html#loading-command-files
 
 1. #### Create your command file in: `src/commands` directory.
     ```node
@@ -90,6 +91,8 @@ Inspired create stand-alone boiler-plate after contributions I had made to a pri
     module.exports = [ ... , myCommand]
     ```
 Done! The bot will set this command on the client during initialization.
+
+Reference: https://discordjs.guide/creating-your-bot/command-handling.html#loading-command-files
 
 ### Registering Commands:
 
@@ -118,7 +121,20 @@ Registering a command globally ***and*** for a guild will result in duplicated c
 
 > Only necessary to run when updating commands. There is a daily limit on registering new commands.
 
-https://discordjs.guide/creating-your-bot/command-deployment.html#command-registration
+Reference: https://discordjs.guide/creating-your-bot/command-deployment.html#command-registration
+
+### Debug Logs
+
+You may add logging to `stdout` whether using developer mode or production using the following flag:
+
+    --debug
+
+- Includes all logs from all scopes of the application.
+- This flag supports arguments with: `--debug="<scope>"`
+
+> For more information on scope, see the `debug` library documentation: https://www.npmjs.com/package/debug#usage
+
+
 
 ## References:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,9 @@
     "": {
       "name": "base-discord-bot-app",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
+        "debug": "^4.3.4",
         "discord.js": "^14.14.1",
         "dotenv": "^16.4.5"
       },
@@ -641,7 +642,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -1703,8 +1703,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/dmartinezgamboa/base-discord-bot-app#readme",
   "dependencies": {
+    "debug": "^4.3.4",
     "discord.js": "^14.14.1",
     "dotenv": "^16.4.5"
   },

--- a/src/bot.js
+++ b/src/bot.js
@@ -1,4 +1,5 @@
 const { Client, Collection } = require("discord.js");
+const { Debug } = require('./utils/debugger')
 const { registerSlashCommands } = require("./utils/registerSlashCommands");
 const { setCommands } = require("./utils/setCommands");
 const { setEvents } = require("./utils/setEvents");
@@ -7,10 +8,10 @@ class Bot extends Client {
     #CLIENT_AUTH;
     #OPTIONS;
     #DATA;
-
+    
     constructor(config) {
         super({ intents: config.intents });
-
+        
         this.commands = new Collection();
 
         this.#DATA = {
@@ -29,34 +30,55 @@ class Bot extends Client {
     }
 
     run() {
-        if (this.#register) {
-            this.#registerSlashCommands();
+        try {
+            this.#debug(this.run.name).log()
+    
+            if (this.#register) {
+                this.#registerSlashCommands();
+            }
+    
+            this.#registerClientCommands();
+            this.#registerClientEvents();    
+            this.#login();
+        } catch(error) {
+            this.#debug(this.run.name).error(error)
         }
-
-        this.#registerClientCommands();
-        this.#registerClientEvents();
-        this.#login();
     }
 
     get #register() {
+        /** Must be logged this way or triggers a stack overflow */
+        this.#debug('#register').log('get')
+
         return this.#OPTIONS.register;
     }
 
+    #debug(...namespace) {
+        const debug = Debug(__filename, Bot.name)
+        return debug(...namespace)
+    }
+
     #login() {
+        this.#debug(this.#login.name).log()
         this.login(this.#CLIENT_AUTH.token);
     }
 
     #registerClientCommands() {
+        this.#debug(this.#registerClientCommands.name).log()
+
         const commands = this.#DATA.commands;
         setCommands(this, commands);
     }
 
     #registerClientEvents() {
+        this.#debug(this.#registerClientEvents.name).log()
+
         const events = this.#DATA.events;
         setEvents(this, events);
     }
 
     #registerSlashCommands() {
+        this.#debug(this.#registerSlashCommands.name).log()
+
         const params = {
             ...this.#CLIENT_AUTH,
             ...this.#OPTIONS,

--- a/src/commands/ping/index.js
+++ b/src/commands/ping/index.js
@@ -1,10 +1,11 @@
 const { SlashCommandBuilder } = require("discord.js");
+const { log } = require('../../utils/debugger')
 
 const pingCommand = {
     data: new SlashCommandBuilder()
         .setName("ping")
         .setDescription("Return Websocket Heartbeat and Roundtrip Latency"),
-    execute,
+    execute: log(__filename, execute),
 };
 
 async function execute(interaction) {

--- a/src/events/interaction/handleApplicationCommand.js
+++ b/src/events/interaction/handleApplicationCommand.js
@@ -1,19 +1,12 @@
+const { log } = require('../../utils/debugger')
+
 const handleApplicationCommand = async (interaction) => {
     if (interaction.isChatInputCommand()) {
         const { commandName } = interaction;
         const command = interaction.client.commands.get(commandName);
 
-        try {
-            await command.execute(interaction);
-            console.log(`Command: '${commandName}' executed`);
-        } catch (error) {
-            console.error(error);
-            await interaction.reply({
-                content: `Something went wrong while executing '${commandName}'!`,
-                ephemeral: true,
-            });
-        }
+        await command.execute(interaction);
     }
 };
 
-module.exports = { handleApplicationCommand };
+module.exports = { handleApplicationCommand: log(__filename, handleApplicationCommand)  };

--- a/src/events/interaction/index.js
+++ b/src/events/interaction/index.js
@@ -1,5 +1,6 @@
 const { BaseInteraction, InteractionType } = require("discord.js");
 const { ApplicationCommandNotImplemented } = require("../../utils/errors");
+const { log } = require('../../utils/debugger')
 const { handleApplicationCommand } = require("./handleApplicationCommand");
 
 /**
@@ -10,9 +11,6 @@ const { handleApplicationCommand } = require("./handleApplicationCommand");
  * https://old.discordjs.dev/#/docs/discord.js/main/class/BaseInteraction
  */
 const execute = (interaction) => {
-    console.log(
-        `User: "${interaction.member.user.username}" interacted with client`
-    );
     switch (interaction.type) {
         case InteractionType.ApplicationCommand:
             handleApplicationCommand(interaction);
@@ -26,7 +24,7 @@ const execute = (interaction) => {
 
 const interactionEvent = {
     name: "interactionCreate",
-    execute,
+    execute: log(__filename, execute),
 };
 
 module.exports = { interactionEvent };

--- a/src/events/ready/index.js
+++ b/src/events/ready/index.js
@@ -1,7 +1,9 @@
+const { log } = require('../../utils/debugger')
+
 const readyEvent = {
     name: "ready",
     once: true,
-    execute,
+    execute: log(__filename, execute),
 };
 
 async function execute(client) {

--- a/src/register.js
+++ b/src/register.js
@@ -1,6 +1,7 @@
 require("dotenv").config();
 
 const commands = require("./commands");
+const { log, configureDebugger } = require('./utils/debugger')
 const { registerSlashCommands } = require("./utils/registerSlashCommands");
 
 const {
@@ -18,5 +19,5 @@ const params = {
     token: TOKEN,
 };
 
-console.log(params);
-registerSlashCommands(params);
+configureDebugger();
+log(registerSlashCommands)(params);

--- a/src/start.js
+++ b/src/start.js
@@ -1,9 +1,14 @@
 const { Bot } = require("./bot.js");
 const { CLIENT_CONFIGURATION } = require("./config.js");
+const { configureDebugger, Debug, log } = require("./utils/debugger.js");
 
 const start = async () => {
+    configureDebugger();
+    const debug = Debug(__filename, start.name)
+    debug().log('starting application')
+    
     const client = new Bot(CLIENT_CONFIGURATION);
-    client.run();
+    client.run()
 };
 
 start();

--- a/src/utils/debugger.js
+++ b/src/utils/debugger.js
@@ -1,0 +1,143 @@
+const path = require('path')
+const { DebuggerArgumentError } = require('./errors')
+
+const { 
+    npm_config_debug: DEBUG,
+    npm_config_params: PARAMS
+ } = process.env
+ 
+/**
+ * Wrapper for debug logging. Prints to `stdout` on `func` invocation and on errors.
+ * Binding the original function to `loggedFunc` also helps associating functions back to their export locations.
+ * `async` is necessary to support asynchronous callbacks.
+ * 
+ * @param {string} fileName should be `__filename` argument for the namespace to generate properly
+ * @param {Function} func the function we want to decorate
+ * @param {...string} messages optional: any additional logging desired during `func` invocation
+ * 
+ * @returns {Function} wrapped function
+ */
+const log = (fileName, func, ...messages) => {
+    const loggedFunc = async (...params) => {
+        const debug = Debug(fileName, func.name)
+        try {
+            debug().log(...messages)
+            if (PARAMS === "true") { debug().params(...params) }
+            
+            return await func(...params)
+        } catch(error) {
+            debug().error(error)
+        }
+    }
+    return loggedFunc.bind(func)
+}
+
+/**
+ * Usage:
+ *  ```
+ *  // additionalNamespaces is optional
+ *  const debug = Debug(__filename, someFunction.name, ...additionalNamespaces)
+ *  // moreNamespaces and messages are optional
+ *  debug(...moreNamespaces).log(...messages)
+ *  ```
+ * 
+ * `debug` also has `error` and `params` methods for special logging
+ * See `Debugger` class for more information
+ * 
+ * @param  {...string} namespaces 
+ * @returns {Debugger.ready} invoking `ready` returns an instance of `Debugger`
+ */
+const Debug = (...namespaces) => {
+    const _debugger = new Debugger(...namespaces)
+    return _debugger.ready.bind(_debugger)
+}
+
+const configureDebugger = () => {
+    process.env.DEBUG = (DEBUG === "true") ? "*" : DEBUG
+};
+
+/**
+ * @function ready returns current instance of Debugger 
+ * @function message logs any message arguments in namespace
+ * @function error logs any arguments with 'error' namespace
+ * @function params logs any arguments with 'params' namespace
+ */
+class Debugger {
+    #debugger;
+    
+    /** @param {...string} namespaces */
+    constructor(...namespaces) {
+        const namespace = Debugger.#generateNamespace(...namespaces)
+
+        /** Importing 'debug' outside of the class body does not work */
+        this.#debugger = require('debug')(namespace)
+    }
+
+    static #generateNamespace(filePath, ...namespaces) {
+        try {
+            if (!filePath) {
+                throw new DebuggerArgumentError("debug() requires a filePath as first argument (__dirname)")
+            }
+            const { name: fileName } = path.parse(filePath)
+            const directoryPath = path.dirname(filePath)
+            const formattedDirectoryPath = path.relative('./', directoryPath)
+
+            var namespace = `${formattedDirectoryPath}:${fileName}`.replaceAll('/', ':')
+
+            namespaces.forEach((name) => {
+                namespace += `:${name}`
+            })
+    
+            return namespace
+
+            } catch(error) {
+                const log = require('debug')("utils:debugger:ERROR")
+                log(error)
+
+            return ""
+        }
+    }
+    
+    #extend(...namespaces) {
+        namespaces.forEach((namespace) => {
+            this.#debugger = this.#debugger.extend(namespace)
+        })
+    }
+
+    /** 
+     * @param {...string} namespaces 
+     * @returns {Debugger} the current instance of Debugger with namespace
+     */
+    ready(...namespaces) {
+        if (namespaces) { this.#extend(...namespaces) }
+        return this
+    }
+    
+    log(...messages) {
+        if (messages.length) {
+            messages.forEach((message) => { this.#debugger(message) })
+        } else {
+            this.#debugger('called')
+        }
+    }
+    
+    error(message) {
+        try {
+            if (!message) {
+                throw new DebuggerArgumentError("Message or Error argument required")
+            }
+            this.#extend("ERROR")
+            this.#debugger(message)
+        } catch(error) {
+            this.#extend('utils:debugger:error:ERROR')
+            this.#debugger(error)
+        }
+    }
+
+    params(...params) {
+        this.#extend('params')
+        this.#debugger({ ...params })
+    }
+}
+
+module.exports = { configureDebugger, Debug, log }

--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -11,4 +11,34 @@ class ApplicationCommandNotImplemented extends Error {
     }
 }
 
-module.exports = { ApplicationCommandNotImplemented };
+class ApplicationCommandError extends Error {
+    constructor(...params) {
+        super(...params);
+
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, ApplicationCommandError);
+        }
+
+        this.name = "ApplicationCommandError";
+        this.date = new Date();
+    }
+}
+
+class DebuggerArgumentError extends Error {
+    constructor(...params) {
+        super(...params);
+
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, DebuggerArgumentError)
+        }
+
+        this.name = "DebuggerArgumentError"
+        this.date = new Date()
+    }
+}
+
+module.exports = { 
+    ApplicationCommandNotImplemented,
+    ApplicationCommandError,
+    DebuggerArgumentError
+};

--- a/src/utils/registerSlashCommands.js
+++ b/src/utils/registerSlashCommands.js
@@ -1,5 +1,6 @@
 const { REST } = require("@discordjs/rest");
 const { Routes } = require("discord-api-types/v9");
+const { log } = require('./debugger')
 
 /**
  * Register commands globally unless a guild_id is provided.
@@ -47,8 +48,8 @@ const registerSlashCommands = async (params) => {
             } application (/) commands!`
         );
     } catch (error) {
-        console.error(error);
+        console.error(error)
     }
 };
 
-module.exports = { registerSlashCommands };
+module.exports = { registerSlashCommands: log(__filename, registerSlashCommands) };

--- a/src/utils/setCommands.js
+++ b/src/utils/setCommands.js
@@ -1,4 +1,5 @@
 const { Client } = require("discord.js");
+const { log } = require('./debugger')
 
 /**
  * Retrieves all commands and attaches to client on start.
@@ -6,14 +7,15 @@ const { Client } = require("discord.js");
  *
  * @param {Client} client
  * @param {Array} commands
- *
+ * 
  * https://discordjs.guide/creating-your-bot/command-handling.html
  */
 function setCommands(client, commands) {
     commands.forEach((command) => {
         client.commands.set(command.data.name, command);
-        console.log(`Command: '${command.data.name}' set on client`);
     });
 }
 
-module.exports = { setCommands };
+module.exports = { 
+    setCommands: log(__filename, setCommands),
+}

--- a/src/utils/setEvents.js
+++ b/src/utils/setEvents.js
@@ -1,11 +1,12 @@
 const { Client } = require("discord.js");
+const { log } = require('./debugger')
 
 /**
  * Retrieves all events listeners on start and registers to client.
  * Add new event listener in src/events.
  *
  * @param {Client} client
- * @param {Array} eventListeners
+ * @param {Array<object>} eventListeners
  *
  * https://discordjs.guide/creating-your-bot/event-handling.html#individual-event-files
  */
@@ -21,8 +22,7 @@ function setEvents(client, eventListeners) {
                 event.execute(...args);
             });
         }
-        console.log(`Event: '${event.name}' set on client`);
     });
 }
 
-module.exports = { setEvents };
+module.exports = { setEvents: log(__filename, setEvents) };


### PR DESCRIPTION
- Installs `debug` node package.
- Updates `README.md` with usage for developers.
- Allows functions to be wrapped with the `log` function.
  - This logs whenever the decorated function has been invoked along with its exported location.
  - If any decorated function throws an error, it is also logged.
- Also handles Errors gracefully for the Application. Individual functions do not need to try catch. (Unless necessary for function behavior of course). But this log will catch any as well.
  - Debating if the log wrapper should also `throw` the error....
- With this implementation, methods are wrapped and aliased on export, so that usage remains the same. 
- Application now supports `--debug` and `--params` flag.
  - supported with any `npm` command
  ```
  Usage
    npm run dev [--debug [--with-args]]

  Options:
    --debug          prints logs on any decorated function invocation
    --with-args      prints any arguments passed into decorated methods
  ``` 

Note: Currently not very ergonomic with logging for classes

Example:
<img width="1437" alt="Screen Shot 2024-03-31 at 7 28 55 PM" src="https://github.com/dmartinezgamboa/base-discord-bot-app/assets/81271595/dbe8d489-9bba-43ad-bcd4-dd71dc0c4382">

Resolves Issues: #10, #28